### PR TITLE
feat: expose observation creation timestamps

### DIFF
--- a/src/mcp_memory/database.py
+++ b/src/mcp_memory/database.py
@@ -545,7 +545,8 @@ class DatabaseManager:
     def _get_observations_full(self, entity_id: int) -> list[Observation]:
         """Return an entity's observations best-first (vote_score DESC, then insertion order)."""
         rows = self._db.execute(
-            "SELECT content, content_hash, vote_score FROM observations WHERE entity_id = ? "
+            "SELECT content, content_hash, vote_score, created_at FROM observations "
+            "WHERE entity_id = ? "
             "ORDER BY vote_score DESC, id",
             (entity_id,),
         ).fetchall()
@@ -554,6 +555,7 @@ class DatabaseManager:
                 content=row["content"],
                 content_hash=row["content_hash"],
                 vote_score=int(row["vote_score"]),
+                created_at=row["created_at"],
             )
             for row in rows
         ]

--- a/src/mcp_memory/models.py
+++ b/src/mcp_memory/models.py
@@ -83,6 +83,7 @@ class Observation:
     content: str
     content_hash: str
     vote_score: int = 0
+    created_at: str | None = None
 
 
 @dataclass

--- a/src/mcp_memory/visualise.py
+++ b/src/mcp_memory/visualise.py
@@ -129,6 +129,7 @@ def get_all_graph_data(
                         "content": o.content,
                         "content_hash": o.content_hash,
                         "vote_score": o.vote_score,
+                        "created_at": o.created_at,
                     }
                     for o in scored
                 ],
@@ -174,7 +175,12 @@ def search_graph(
             "updated_at": entity.updated_at,
             "vote_score": entity.vote_score,
             "observations": [
-                {"content": o.content, "content_hash": o.content_hash, "vote_score": o.vote_score}
+                {
+                    "content": o.content,
+                    "content_hash": o.content_hash,
+                    "vote_score": o.vote_score,
+                    "created_at": o.created_at,
+                }
                 for o in entity.observations
             ],
         }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2366,6 +2366,13 @@ def _fetch_entity_row(db: DatabaseManager, name: str) -> tuple[sqlite3.Row, int]
 
 
 class TestBuildEntityBudget:
+    def test_observation_created_at_is_returned(self, db: DatabaseManager) -> None:
+        db.create_entities("proj", [{"name": "e1", "entityType": "task", "observations": ["obs1"]}])
+
+        observation = db.get_entity("proj", "e1").observations[0]
+
+        assert observation.created_at is not None
+
     def test_default_budget_applied_via_none(self, db: DatabaseManager) -> None:
         db.create_entities(
             "proj", [{"name": "e1", "entityType": "task", "observations": ["obs1", "obs2"]}]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -680,6 +680,7 @@ class TestSearchNodesObservationShape:
         assert observation.content == "needle"
         assert observation.content_hash == _hash_observation("needle")
         assert observation.vote_score == 0
+        assert observation.created_at is not None
 
 
 class TestRestoreEntityTool:

--- a/tests/test_visualise.py
+++ b/tests/test_visualise.py
@@ -87,7 +87,10 @@ class TestGetAllGraphData:
         assert entity["entity_type"] == "task"
         observations = cast("list[dict[str, object]]", entity["observations"])
         assert [o["content"] for o in observations] == ["obs1", "obs2"]
-        assert all("content_hash" in o and "vote_score" in o for o in observations)
+        assert all(
+            "content_hash" in o and "vote_score" in o and "created_at" in o for o in observations
+        )
+        assert all(o["created_at"] is not None for o in observations)
         assert entity["status"] == "planned"
         assert entity["vote_score"] == 1
 
@@ -671,6 +674,7 @@ class TestSearchGraph:
                     "content": "deployment pipeline",
                     "content_hash": _hash_observation("deployment pipeline"),
                     "vote_score": 0,
+                    "created_at": entity["observations"][0]["created_at"],
                 }
             ],
         }


### PR DESCRIPTION
Fixes #9

## Summary

- Add `created_at` to the `Observation` model with a `None` default for synthetic budget-sentinel observations.
- Load the existing SQLite observation timestamp in `_get_observations_full`.
- Include the timestamp in both visualisation serialization paths.
- Add focused database, MCP search, and visualisation response-shape tests.

## Verification

- `uv run pytest -q` — 940 passed, 2 skipped.
- Focused database/server/visualisation tests — 461 passed.
- `uv run ruff format --check src/ tests/` — passed.
- Targeted Ruff check on modified files, excluding repository-wide legacy rules — passed.
- Targeted mypy check on modified modules, excluding unrelated optional-hook imports and one existing no-any-return warning — passed.

## Existing repository blockers

- Full `uv run ruff check src/ tests/` still reports 59 pre-existing violations: CPY001 copyright notices, PLR0917 argument-count findings, and ISC004 string-concatenation findings outside this change.
- Default `uv run mypy src/` still fails in `src/mcp_memory/hooks/plugin.py` because the optional `cline_hooks.core.plugin` dependency is not installed; the downstream subclass error is pre-existing.

No migrations are required because the observations table already contains `created_at`.