### PR TITLE
ci: add GitHub Actions checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Lint
+        run: uv run ruff check src/ tests/
+
+      - name: Format
+        run: uv run ruff format --check src/ tests/
+
+      - name: Type check
+        run: uv run mypy src/
+
+      - name: Test
+        run: uv run pytest


### PR DESCRIPTION
## Related issue

Fixes #17

## Summary

- Add a GitHub Actions workflow for pushes and pull requests.
- Run lint, format, type-check, and test as separate reported steps.
- Use Python 3.12 and the repository's existing `uv sync --dev` dependency setup.
- Enable uv caching and read-only repository contents permissions.

## Implementation and compatibility

The workflow uses the existing commands and dependency group from `pyproject.toml`/`justfile`; it does not change application code or runtime behavior. It runs on Ubuntu with Python 3.12, matching the project's declared minimum Python version.

## Verification

- `git diff --check` — passed.
- `python -m ruff format --check src/ tests/` — passed (57 files already formatted).
- `uv sync --dev` — dependency resolution and local package build succeeded, but downloading the `ruff` and `mypy` binaries stalled in the local network environment.
- `uv run ruff check src/ tests/` — not completed because the uv binary download stalled.
- `uv run mypy src/` — not completed because the uv binary download stalled.
- `uv run pytest` — not completed because the uv binary download stalled.
- Host-side `mypy src/` reports existing baseline errors, including the optional `cline_hooks` dependency and platform-specific `fcntl`/`os.getuid` checks.
- Host-side `pytest` cannot collect tests because the project package/dependencies are not installed in the host interpreter.

## Known limitations

The workflow intentionally reports the repository's existing lint/type-check/test state; it does not weaken checks or modify unrelated baseline failures.